### PR TITLE
add modulemap and CBBSwift3RemoteExport to support Swift3

### DIFF
--- a/CBBFunctionChannel.modulemap
+++ b/CBBFunctionChannel.modulemap
@@ -1,0 +1,9 @@
+framework module CBBFunctionChannel {
+
+header "CBBAsyncResult.h"
+header "CBBFunctionChannel.h"
+header "CBBRemoteExport.h"
+header "CBBRemoteExportUtility.h"
+
+}
+

--- a/CBBFunctionChannel.podspec
+++ b/CBBFunctionChannel.podspec
@@ -9,4 +9,6 @@ Pod::Spec.new do |s|
   s.source = { :git => "https://github.com/cross-border-bridge/function-channel-ios.git", :tag => "#{s.version}" }
   s.source_files = "CBBFunctionChannel/**/*.{h,m}"
   s.dependency "CBBDataChannel", "~> 2.0.4"
+  s.preserve_path = "CBBFunctionChannel.modulemap"
+  s.module_map = "CBBFunctionChannel.modulemap"
 end

--- a/CBBFunctionChannel/CBBRemoteExport.h
+++ b/CBBFunctionChannel/CBBRemoteExport.h
@@ -5,6 +5,9 @@
 @protocol CBBRemoteExport <NSObject>
 @end
 
+@protocol CBBSwift3RemoteExport <CBBRemoteExport>
+@end
+
 #define CBBRemoteExportAs(PropertyName, Selector)                   \
     @optional                                                       \
     Selector __CBB_REMOTE_EXPORT_AS__##PropertyName : (id)argument; \

--- a/CBBFunctionChannel/CBBRemoteExportUtility.m
+++ b/CBBFunctionChannel/CBBRemoteExportUtility.m
@@ -4,54 +4,104 @@
 #import "CBBRemoteExportUtility.h"
 #import <objc/runtime.h>
 
+typedef NS_ENUM(NSUInteger, CBBMethodNamingConvension) {
+    CBBMethodNamingConvension_ObjC,
+    CBBMethodNamingConvension_Swift3,
+};
+
+@interface CBBRemoteMethodInfo : NSObject
+@property (nonatomic) NSString* fullname;
+@property (nonatomic) CBBMethodNamingConvension convention;
+@end
+
+@implementation CBBRemoteMethodInfo
+
++ (CBBRemoteMethodInfo*)infoByName:(NSString*)name convention:(CBBMethodNamingConvension)convention
+{
+    CBBRemoteMethodInfo* info = [[CBBRemoteMethodInfo alloc] init];
+    if (info) {
+        info.fullname = name;
+        info.convention = convention;
+    }
+    return info;
+}
+
+- (NSString*)extractKeyMethodName
+{
+    if (_convention == CBBMethodNamingConvension_ObjC) {
+        NSMutableArray<NSString*>* array = [[_fullname componentsSeparatedByString:@":"] mutableCopy];
+        for (int i = 0; i < array.count; ++i) {
+            array[i] = i ? array[i].capitalizedString : array[i];
+        }
+        return [array componentsJoinedByString:@""];
+    } else {
+        NSMutableArray<NSString*>* array = [[_fullname componentsSeparatedByString:@":"] mutableCopy];
+        for (int i = 0; i < array.count; ++i) {
+            if (i == 0) {
+                NSRange range = [array[i] rangeOfString:@"With"];
+                if (range.location != NSNotFound) {
+                    array[i] = [array[i] substringToIndex:range.location];
+                }
+            } else {
+                array[i] = array[i].capitalizedString;
+            }
+        }
+        return [array componentsJoinedByString:@""];
+    }
+}
+
+@end
+
 @implementation CBBRemoteExportUtility
 
 + (NSDictionary<NSString*, NSString*>*)exportRemoteExportMethodTableFromClass:(Class)cls
 {
     NSArray* protocols = [CBBRemoteExportUtility protocolsConformsToPortocol:@protocol(CBBRemoteExport) class:cls];
-    NSArray* methods = [CBBRemoteExportUtility methodsConformsToProtocolNames:protocols];
+    NSArray<CBBRemoteMethodInfo*>* methods = [CBBRemoteExportUtility methodsConformsToProtocolNames:protocols];
     NSDictionary* result = [self remoteExportMethodTableFromMethodNames:methods];
     return result;
 }
 
-+ (NSDictionary<NSString*, NSString*>*)remoteExportMethodTableFromMethodNames:(NSArray*)methodNames
++ (NSDictionary<NSString*, NSString*>*)remoteExportMethodTableFromMethodNames:(NSArray<CBBRemoteMethodInfo*>*)methodNames
 {
     NSMutableDictionary* result = [NSMutableDictionary dictionary];
-    [methodNames enumerateObjectsUsingBlock:^(id _Nonnull obj, NSUInteger idx, BOOL* _Nonnull stop) {
-        NSRange range = [obj rangeOfString:@"__CBB_REMOTE_EXPORT_AS__"];
+    [methodNames enumerateObjectsUsingBlock:^(CBBRemoteMethodInfo* _Nonnull obj, NSUInteger idx, BOOL* _Nonnull stop) {
+        NSRange range = [obj.fullname rangeOfString:@"__CBB_REMOTE_EXPORT_AS__"];
         if (range.location == NSNotFound) {
-            NSString* keyMethodName = ^() {
-                NSMutableArray<NSString*>* array = [[obj componentsSeparatedByString:@":"] mutableCopy];
-                for (int i = 0; i < array.count; ++i) {
-                    array[i] = i ? array[i].capitalizedString : array[i];
-                }
-                return [array componentsJoinedByString:@""];
-            }();
-            result[keyMethodName] = obj;
+            NSString* keyMethodName = [obj extractKeyMethodName];
+            result[keyMethodName] = obj.fullname;
         } else {
-            NSString* originalMethodName = [obj substringToIndex:range.location];
-            NSString* aliasMethodName = [obj substringFromIndex:range.location + range.length];
+            NSString* originalMethodName = [obj.fullname substringToIndex:range.location];
+            NSString* aliasMethodName = [obj.fullname substringFromIndex:range.location + range.length];
             result[[aliasMethodName substringToIndex:aliasMethodName.length - 1]] = originalMethodName;
         }
     }];
     return result;
 }
 
-+ (NSArray<NSString*>*)methodsConformsToProtocolNames:(NSArray*)protocolNames
++ (NSArray<CBBRemoteMethodInfo*>*)methodsConformsToProtocolNames:(NSArray*)protocolNames
 {
     NSMutableArray* result = [NSMutableArray array];
     for (NSString* protocolName in protocolNames) {
         Protocol* protocol = NSProtocolFromString(protocolName);
+        CBBMethodNamingConvension convention =
+            protocol_conformsToProtocol(protocol, @protocol(CBBSwift3RemoteExport))
+                ? CBBMethodNamingConvension_Swift3
+                : CBBMethodNamingConvension_ObjC;
         unsigned int count = 0;
         struct objc_method_description* required_method_descriptions = protocol_copyMethodDescriptionList(protocol, YES, YES, &count);
         for (unsigned int i = 0; i < count; ++i) {
-            [result addObject:NSStringFromSelector(required_method_descriptions[i].name)];
+            [result addObject:[CBBRemoteMethodInfo
+                                  infoByName:NSStringFromSelector(required_method_descriptions[i].name)
+                                  convention:convention]];
         }
         free(required_method_descriptions);
         count = 0;
         struct objc_method_description* optional_method_descriptions = protocol_copyMethodDescriptionList(protocol, NO, YES, &count);
         for (unsigned int i = 0; i < count; ++i) {
-            [result addObject:NSStringFromSelector(optional_method_descriptions[i].name)];
+            [result addObject:[CBBRemoteMethodInfo
+                                  infoByName:NSStringFromSelector(optional_method_descriptions[i].name)
+                                  convention:convention]];
         }
         free(optional_method_descriptions);
     }


### PR DESCRIPTION
CBBFunctionChannelをSwiftから引けるようにmodulemapを追加します。

また、Swift3のメソッド名生成規則に対応するCBBSwift3RemoteExportを追加します。