### PR TITLE
RemoteExportMethodの取得方法を変更

### DIFF
--- a/CBBFunctionChannel.podspec
+++ b/CBBFunctionChannel.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name = "CBBFunctionChannel"
-  s.version = "2.0.6"
+  s.version = "2.0.7"
   s.summary = "FunctionChannel for iOS"
   s.homepage = "https://github.com/cross-border-bridge/function-channel-ios"
   s.author = 'DWANGO Co., Ltd.'


### PR DESCRIPTION
- CBBRemoteExportUtility#exportRemoteExportMethodTableFromClass: では、protocolsConformsToPortocol: で一旦Protocolをプロトコル名に変換してから、methodsConformsToProtocolNames: でプロトコル名を再度Protocolに戻すという、冗長な処理が行われています。

- また、CBBRemoteExportUtility#methodsConformsToProtocolNames: の内部で実行している、NSProtocolFromString() が、Xcode11GMでビルドしたバイナリをiOS13GMで実行した際に、Swiftのプロトコル名を与えた際に、常にnilを返してくることがわかりました。

- このため、protocolsConformsToPortocol: と、methodsConformsToProtocolNames: を一つのメソッドにまとめ、冗長と考えられるプロトコル名への変換を行わないよう変更しました。
